### PR TITLE
fix: shaka buffering behaviour detection

### DIFF
--- a/src/VideoEventFilter.ts
+++ b/src/VideoEventFilter.ts
@@ -85,6 +85,7 @@ export class VideoEventFilter extends EmitterBaseClass {
     this.addListener("seeking", this.onSeeking);
     this.addListener("seeked", this.onSeeked);
     this.addListener("waiting", this.onBuffering);
+    this.addListener("ratechange", this.onRateChange);
     this.addListener("timeupdate", this.onTimeUpdate);
     this.addListener("error", this.onError);
     this.addListener("ended", this.onEnded);
@@ -175,6 +176,16 @@ export class VideoEventFilter extends EmitterBaseClass {
     if (this.state !== PlayerState.Buffering) return;
     this.setState(this.lastState, true);
     this.emit(PlayerEvents.Buffered);
+  }
+
+  private onRateChange(): void {
+    if (this.videoElement.playbackRate > 0) return;
+    const isBuffering =
+      this.videoElement.playbackRate === 0 &&
+      this.videoElement.paused === false;
+    if (isBuffering) {
+      this.onBuffering();
+    }
   }
 
   private onTimeUpdate(): void {


### PR DESCRIPTION
Shaka doesn't always trigger waiting when going into buffering, but rather sets the playback rate to 0, then triggering its own methods.
https://github.com/shaka-project/shaka-player/issues/2093

This change might be opinionated but would detect these reports, as the playback rate is 0 but the player is not paused.
The only other scenario when this happens AFAIK is if the user turns the playback rate to 0.

Scenarios verified
- [x] State on player start
- [x] State during scrubbing
- [x] State during pause
- [x] State during scrubbing
- [x] State at end